### PR TITLE
fix: Fix broken badge for CI pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk SOAR Extension for VS Code
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/splunk/vscode-extension-splunk-soar/CI)
+[![GitHub Workflow Status](https://github.com/splunk/vscode-extension-splunk-soar/actions/workflows/ci.yml/badge.svg)](https://github.com/splunk/vscode-extension-splunk-soar/actions/workflows/ci.yml)
 [![Slack](https://img.shields.io/badge/Slack-soar__app__dev-blue?logo=slack)](https://splunk-usergroups.slack.com/archives/C03FYT64AJZ)
 
 


### PR DESCRIPTION
Hey! 👋🏼 

Just a small fix that should display the build status on the badge in README.md 