### PR TITLE
Add token authentication option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-splunk-soar",
-	"version": "0.0.30",
+	"version": "0.0.33",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-splunk-soar",
-			"version": "0.0.30",
+			"version": "0.0.33",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/core": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"icon": "media/soarcloud.png",
 	"publisher": "Splunk",
 	"license": "Apache-2.0",
-	"version": "0.0.32",
+	"version": "0.0.33",
 	"engines": {
 		"vscode": "^1.72.0"
 	},

--- a/src/commands/environments/addEnvironmentWizard.ts
+++ b/src/commands/environments/addEnvironmentWizard.ts
@@ -3,7 +3,7 @@ import {MultiStepInput} from '../../wizard/MultiStepInput'
 import { ConnectEnvironment } from './environments';
 
 const wizardTitle = "Add Environment"
-const totalSteps = 4
+const totalSteps = 5
 
 function shouldResume() {
     // Could show a notification with the option to resume.
@@ -44,13 +44,37 @@ async function connectSslVerifyInput(input: MultiStepInput, state: Partial<Conne
         canSelectMany: false
     });
     state.sslVerify = sslPick[0].label === "Yes"
-    return (input: MultiStepInput) => conectUsernameInput(input, state);
+    return (input: MultiStepInput) => authTypeInput(input, state);
 }
 
-async function conectUsernameInput(input: MultiStepInput, state: Partial<ConnectEnvironment>){
-    state.username = await input.showInputBox({
+async function authTypeInput(input: MultiStepInput, state: Partial<ConnectEnvironment>){
+    let authPick = await input.showQuickPick({
         title: wizardTitle,
         step: 3,
+        totalSteps: totalSteps,
+        placeholder: 'Auth type',
+        value: state.authType || '',
+        items: [{"label": "local"}, {"label": "token"}],
+        shouldResume: shouldResume,
+        ignoreFocusOut: true,
+        canSelectMany: false
+    });
+
+    if (authPick[0].label === "local") {
+        state.authType = "local";
+        return (input: MultiStepInput) => connectUsernameInput(input, state);
+    }
+    else {
+        state.authType = "token";
+        return (input: MultiStepInput) => connectTokenNameInput(input, state);
+    }
+
+}
+
+async function connectUsernameInput(input: MultiStepInput, state: Partial<ConnectEnvironment>){
+    state.username = await input.showInputBox({
+        title: wizardTitle,
+        step: 4,
         totalSteps: totalSteps,
         value: state.username || '',
         prompt: `Username`,
@@ -62,10 +86,41 @@ async function conectUsernameInput(input: MultiStepInput, state: Partial<Connect
     return (input: MultiStepInput) => connectPasswordInput(input, state);
 }
 
+async function connectTokenNameInput(input: MultiStepInput, state: Partial<ConnectEnvironment>){
+    state.username = await input.showInputBox({
+        title: wizardTitle,
+        step: 4,
+        totalSteps: totalSteps,
+        value: state.username || '',
+        prompt: `Token name`,
+        shouldResume: shouldResume,
+        validate: validateNameIsUnique,
+        ignoreFocusOut: true
+    });
+
+    return (input: MultiStepInput) => connectTokenInput(input, state);
+}
+
+async function connectTokenInput(input: MultiStepInput, state: Partial<ConnectEnvironment>){
+    state.password = await input.showInputBox({
+        title: wizardTitle,
+        step: 5,
+        totalSteps: totalSteps,
+        value: '',
+        prompt: `Token`,
+        shouldResume: shouldResume,
+        validate: validateNameIsUnique,
+        isPassword: true,
+        ignoreFocusOut: true
+    });
+
+    return;
+}
+
 async function connectPasswordInput(input: MultiStepInput, state: Partial<ConnectEnvironment>){
     state.password = await input.showInputBox({
         title: wizardTitle,
-        step: 4,
+        step: 5,
         totalSteps: totalSteps,
         value: '',
         prompt: `Password`,

--- a/src/soar/client.ts
+++ b/src/soar/client.ts
@@ -16,7 +16,7 @@ export class SoarClient {
     httpClient: AxiosInstance
     fileClient: AxiosInstance
 
-    constructor(server: string, username: string, password: string, sslVerify: boolean) {
+    constructor(server: string, authType: string, username: string, password: string, sslVerify: boolean) {
         this.server = server
         this.username = username
         this.password = password
@@ -24,7 +24,8 @@ export class SoarClient {
 
         const axiosConfig = {
             baseURL: `${server}/rest/`,
-            auth: {username: username, password: password},
+            ...(authType === "local" && {auth: {username: username, password: password}}),
+            ...(authType === "token" && {headers: {"ph-auth-token": password} })
         }
 
         this.httpClient = axios.create(axiosConfig)
@@ -277,14 +278,14 @@ export class SoarClient {
 
 export async function getClientForActiveEnvironment(context: vscode.ExtensionContext): Promise<SoarClient> {
 
-    let {url, username, sslVerify, password} = await getActiveEnvironment(context)
+    let {url, username, sslVerify, password, authType} = await getActiveEnvironment(context)
 
-    return new SoarClient(url, username, password, sslVerify)
+    return new SoarClient(url, authType, username, password, sslVerify)
 }
 
 export async function getClientForEnvironment(context: vscode.ExtensionContext, envKey: string): Promise<SoarClient> {
 
-    let {url, username, sslVerify, password} = await getEnvironment(context, envKey)
+    let {url, username, sslVerify, password, authType} = await getEnvironment(context, envKey)
 
-    return new SoarClient(url, username, password, sslVerify)
+    return new SoarClient(url, authType, username, password, sslVerify)
 }


### PR DESCRIPTION
Hey there! I'm not sure it's idiomatic Typescript, but for my own purposes I implemented token-based authentication and figured I'd open a PR. It adds a new step to the environment creation wizard and a new property to the `BaseConnectEnvironment` interface. It should be backwards-compatible with environments created on older version too. 

#125 